### PR TITLE
Refactor `no_hints` method to use `ctx.channel` instead of `channel.send`.

### DIFF
--- a/src/cmds/core/other.py
+++ b/src/cmds/core/other.py
@@ -1,7 +1,6 @@
 import logging
 
-from discord import ApplicationContext, Embed, Interaction, Message, Option, WebhookMessage, slash_command
-from discord.abc import GuildChannel
+from discord import ApplicationContext, Embed, Interaction, Message, WebhookMessage, slash_command
 from discord.ext import commands
 
 from src.bot import Bot
@@ -21,7 +20,7 @@ class OtherCog(commands.Cog):
         self, ctx: ApplicationContext
     ) -> Message:
         """A simple reply stating hints are not allowed."""
-        return await channel.send(
+        return await ctx.channel.send(
             "No hints are allowed for the duration the event is going on. This is a competitive event with prizes. "
             "Once the event is over you are more then welcome to share solutions/write-ups/etc and try them in the "
             "After Party event."

--- a/tests/src/cmds/core/test_other.py
+++ b/tests/src/cmds/core/test_other.py
@@ -13,6 +13,7 @@ class TestOther:
     async def test_no_hints(self, bot, ctx):
         """Test the response of the `no_hints` command."""
         cog = other.OtherCog(bot)
+        ctx.bot = bot
 
         # Invoke the command.
         await cog.no_hints.callback(cog, ctx)


### PR DESCRIPTION
Use `ctx.channel` to avoid users writing to channels they don't have access.

## Types of changes

What types of changes does your code introduce?
*Put an `x` in the boxes that apply.*

- [X] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes
Use `ctx.channel` instead of passing channel as a parameter.

## Checklist

*Put an `x` in the boxes that apply.*

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [X] Lint and unit tests pass locally with my changes.
- [X] I have added the necessary documentation (if appropriate).
