### PR TITLE
Update the user.py to link to the correct profile

### DIFF
--- a/src/cmds/core/user.py
+++ b/src/cmds/core/user.py
@@ -231,7 +231,7 @@ class UserCog(commands.Cog):
         embed.add_field(name="Discord ID:", value=str(fetched_user.id), inline=True)
         embed.add_field(
             name="HTB Profile:",
-            value=f"<https://www.hackthebox.com/home/users/profile/{htb_discord_link.htb_user_id}>",
+            value=f"<https://app.hackthebox.com/users/{htb_discord_link.htb_user_id}>",
             inline=False,
         )
         embed.set_footer(text=f"More info: /history user:{fetched_user.id}")


### PR DESCRIPTION
At the moment the user profile url results in a 404. Updated the url to the correct format.

## Types of changes

What types of changes does your code introduce?
*Put an `x` in the boxes that apply.*

- [X] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes

Updated the url to link to a profile on the Labs platform. Example: https://app.hackthebox.com/users/301447

## Checklist

*Put an `x` in the boxes that apply.*

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [X] Lint and unit tests pass locally with my changes.
- [ ] I have added the necessary documentation (if appropriate).


