### PR TITLE
[FEATURE] Evidence field for `/kick`

### DIFF
--- a/tests/src/cmds/core/test_ban.py
+++ b/tests/src/cmds/core/test_ban.py
@@ -22,7 +22,7 @@ class TestBanCog:
         bot.get_member_or_user.return_value = user
 
         with patch('src.cmds.core.ban.ban_member', new_callable=AsyncMock) as ban_member_mock, \
-             patch('src.cmds.core.ban.BanCog.add_evidence_note', new_callable=AsyncMock) as add_evidence_note_mock:
+             patch('src.cmds.core.ban.add_evidence_note', new_callable=AsyncMock) as add_evidence_note_mock:
             ban_response = SimpleResponse(
                 message=f"Member {user.display_name} has been banned permanently.", delete_after=0
             )
@@ -32,7 +32,7 @@ class TestBanCog:
             await cog.ban.callback(cog, ctx, user, "Any valid reason", "Some evidence")
 
             # Assertions
-            add_evidence_note_mock.assert_called_once_with(user.id, "Any valid reason", "Some evidence", ctx.user.id)
+            add_evidence_note_mock.assert_called_once_with(user.id, "ban", "Any valid reason", "Some evidence", ctx.user.id)
             ban_member_mock.assert_called_once_with(
                 bot, ctx.guild, user, "500w", "Any valid reason", ctx.user, needs_approval=False
             )
@@ -48,7 +48,7 @@ class TestBanCog:
 
         with patch('src.helpers.ban.validate_duration', new_callable=AsyncMock) as validate_duration_mock, \
              patch('src.cmds.core.ban.ban_member', new_callable=AsyncMock) as ban_member_mock, \
-             patch('src.cmds.core.ban.BanCog.add_evidence_note', new_callable=AsyncMock) as add_evidence_note_mock:
+             patch('src.cmds.core.ban.add_evidence_note', new_callable=AsyncMock) as add_evidence_note_mock:
             validate_duration_mock.return_value = (calendar.timegm(time.gmtime()) + parse_duration_str("5d"), "")
             ban_response = SimpleResponse(
                 message=f"Member {user.display_name} has been banned temporarily.", delete_after=0
@@ -59,7 +59,7 @@ class TestBanCog:
             await cog.tempban.callback(cog, ctx, user, "5d", "Any valid reason", "Some evidence")
 
             # Assertions
-            add_evidence_note_mock.assert_called_once_with(user.id, "Any valid reason", "Some evidence", ctx.user.id)
+            add_evidence_note_mock.assert_called_once_with(user.id, "ban", "Any valid reason", "Some evidence", ctx.user.id)
             ban_member_mock.assert_called_once_with(
                 bot, ctx.guild, user, "5d", "Any valid reason", ctx.user, needs_approval=True
             )

--- a/tests/src/cmds/core/test_user.py
+++ b/tests/src/cmds/core/test_user.py
@@ -1,8 +1,36 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
 from src.cmds.core import user
+from tests import helpers
 
 
 class TestUserCog:
     """Test the `User` cog."""
+
+    @pytest.mark.asyncio
+    async def test_kick_success(self, ctx, bot):
+        ctx.user = helpers.MockMember(id=1, name="Test Moderator")
+        user_to_kick = helpers.MockMember(id=2, name="User to Kick", bot=False)
+        ctx.guild.kick = AsyncMock()
+        bot.get_member_or_user = AsyncMock(return_value=user_to_kick)
+
+        # Mock the DM channel
+        user_to_kick.send = AsyncMock()
+        user_to_kick.name = "User to Kick"
+
+        with patch('src.cmds.core.user.add_evidence_note', new_callable=AsyncMock) as add_evidence_mock, \
+                patch('src.cmds.core.user.member_is_staff', return_value=False):
+            cog = user.UserCog(bot)
+            await cog.kick.callback(cog, ctx, user_to_kick, "Violation of rules")
+
+            add_evidence_mock.assert_called_once_with(user_to_kick.id, "kick", "Violation of rules", None, ctx.user.id)
+
+            # Assertions
+            ctx.guild.kick.assert_called_once_with(user=user_to_kick, reason="Violation of rules")
+            ctx.respond.assert_called_once_with("User to Kick got the boot!")
+
 
     def test_setup(self, bot):
         """Test the setup method of the cog."""

--- a/tests/src/cmds/core/test_user.py
+++ b/tests/src/cmds/core/test_user.py
@@ -20,8 +20,10 @@ class TestUserCog:
         user_to_kick.send = AsyncMock()
         user_to_kick.name = "User to Kick"
 
-        with patch('src.cmds.core.user.add_evidence_note', new_callable=AsyncMock) as add_evidence_mock, \
-                patch('src.cmds.core.user.member_is_staff', return_value=False):
+        with (
+            patch('src.cmds.core.user.add_evidence_note', new_callable=AsyncMock) as add_evidence_mock, 
+            patch('src.cmds.core.user.member_is_staff', return_value=False
+        ):
             cog = user.UserCog(bot)
             await cog.kick.callback(cog, ctx, user_to_kick, "Violation of rules")
 


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
*Put an `x` in the boxes that apply.*

- [ ] Bugfix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes

This PR adds the evidence option to the `/kick` command. 
I have refactored the code a bit.
* moved the add_evicence_note to the ban helper
* Altered ban function + tests
* Added a test case for kicking a user and adding a note

I received a false positive from the lint saying the arrow import is unused, but this is false. 

## Checklist

*Put an `x` in the boxes that apply.*

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [X] Lint and unit tests pass locally with my changes.
- [X] I have added the necessary documentation (if appropriate).

## Additional context
