### PR TITLE
[FEATURE] - Add option to `/support` for sending Academy support link

### DIFF
--- a/src/cmds/core/other.py
+++ b/src/cmds/core/other.py
@@ -1,7 +1,7 @@
 import logging
 
 import discord
-from discord import ApplicationContext, Embed, Interaction, Message, WebhookMessage, slash_command
+from discord import ApplicationContext, Embed, Interaction, Message, Option, WebhookMessage, slash_command
 from discord.ext import commands
 from discord.ui import InputText, Modal
 from slack_sdk.webhook import WebhookClient
@@ -74,22 +74,16 @@ class OtherCog(commands.Cog):
                    description="A simple reply proving a link to the support desk article on how to get support")
     @commands.cooldown(1, 60, commands.BucketType.user)
     async def support(
-            self, ctx: ApplicationContext
+            self, ctx: ApplicationContext,
+            platform: Option(str, "Select the platform", choices=["labs", "academy"], default="labs"),
     ) -> Message:
-        """A simple reply proving a link to the support desk article on how to get support."""
+        """A simple reply providing a link to the support desk article on how to get support."""
+        if platform == "academy":
+            return await ctx.respond(
+                "https://help.hackthebox.com/en/articles/5987511-contacting-academy-support"
+            )
         return await ctx.respond(
             "https://help.hackthebox.com/en/articles/5986762-contacting-htb-support"
-        )
-
-    @slash_command(guild_ids=settings.guild_ids,
-                   description="A simple reply providing a link to the support desk article for HTB Academy")
-    @commands.cooldown(1, 60, commands.BucketType.user)
-    async def academysupport(
-            self, ctx: ApplicationContext
-    ) -> Message:
-        """A simple reply providing a link to the support desk article for HTB Academy."""
-        return await ctx.respond(
-            "https://help.hackthebox.com/en/articles/5987511-contacting-academy-support"
         )
 
     @slash_command(guild_ids=settings.guild_ids, description="Add the URL which has spoiler link.")

--- a/tests/src/cmds/core/test_other.py
+++ b/tests/src/cmds/core/test_other.py
@@ -27,13 +27,32 @@ class TestOther:
         assert content.startswith("No hints are allowed")
 
     @pytest.mark.asyncio
-    async def test_support(self, bot, ctx):
+    async def test_support_labs(self, bot, ctx):
         """Test the response of the `support` command."""
         cog = other.OtherCog(bot)
         ctx.bot = bot
+        platform = "labs"
 
         # Invoke the command.
-        await cog.support.callback(cog, ctx)
+        await cog.support.callback(cog, ctx, platform)
+
+        args, kwargs = ctx.respond.call_args
+        content = args[0]
+
+        # Command should respond with a string.
+        assert isinstance(content, str)
+
+        assert content.startswith("https://help.hackthebox.com")
+
+    @pytest.mark.asyncio
+    async def test_support_academy(self, bot, ctx):
+        """Test the response of the `support` command."""
+        cog = other.OtherCog(bot)
+        ctx.bot = bot
+        platform = "academy"
+
+        # Invoke the command.
+        await cog.support.callback(cog, ctx, platform)
 
         args, kwargs = ctx.respond.call_args
         content = args[0]

--- a/tests/src/cmds/core/test_other.py
+++ b/tests/src/cmds/core/test_other.py
@@ -42,7 +42,7 @@ class TestOther:
         # Command should respond with a string.
         assert isinstance(content, str)
 
-        assert content.startswith("https://help.hackthebox.com")
+        assert content == "https://help.hackthebox.com/en/articles/5986762-contacting-htb-support"
 
     @pytest.mark.asyncio
     async def test_support_academy(self, bot, ctx):
@@ -60,7 +60,7 @@ class TestOther:
         # Command should respond with a string.
         assert isinstance(content, str)
 
-        assert content.startswith("https://help.hackthebox.com")
+        assert content == "https://help.hackthebox.com/en/articles/5987511-contacting-academy-support"
 
     @pytest.mark.asyncio
     async def test_spoiler_without_url(self, bot, ctx):

--- a/tests/src/cmds/core/test_other.py
+++ b/tests/src/cmds/core/test_other.py
@@ -63,6 +63,23 @@ class TestOther:
         assert content == "https://help.hackthebox.com/en/articles/5987511-contacting-academy-support"
 
     @pytest.mark.asyncio
+    async def test_support_urls_different(self, bot, ctx):
+        """Test that the URLs for 'labs' and 'academy' platforms are different."""
+        cog = other.OtherCog(bot)
+        ctx.bot = bot
+
+        # Test the 'labs' platform
+        await cog.support.callback(cog, ctx, "labs")
+        labs_url = ctx.respond.call_args[0][0]
+
+        # Test the 'academy' platform
+        await cog.support.callback(cog, ctx, "academy")
+        academy_url = ctx.respond.call_args[0][0]
+
+        # Assert that the URLs are different
+        assert labs_url != academy_url
+
+    @pytest.mark.asyncio
     async def test_spoiler_without_url(self, bot, ctx):
         """Test the response of the `spoiler` command without url."""
         cog = other.OtherCog(bot)


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
*Put an `x` in the boxes that apply.*

- [ ] Bugfix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes

Adds the option to provide a link to Academy support via `/support` . This will allow the person who runs the command to choose between "labs" and "academy". Labs is default. Screenshots in comment below.

## Checklist

*Put an `x` in the boxes that apply.*

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [X] Lint and unit tests pass locally with my changes.
- [X] I have added the necessary documentation (if appropriate).

## Additional context


