### PR TITLE
[FEATURE] Add evidence field in the ban request overview

### DIFF
--- a/src/cmds/core/ban.py
+++ b/src/cmds/core/ban.py
@@ -35,7 +35,9 @@ class BanCog(commands.Cog):
         if not member:
             return await ctx.respond(f"User {user} not found.")
         await add_evidence_note(member.id, "ban", reason, evidence, ctx.user.id)
-        response = await ban_member(self.bot, ctx.guild, member, "500w", reason, ctx.user, needs_approval=False)
+        response = await ban_member(
+            self.bot, ctx.guild, member, "500w", reason, evidence, ctx.user, needs_approval=False
+        )
         return await ctx.respond(response.message, delete_after=response.delete_after)
 
     @slash_command(
@@ -53,7 +55,9 @@ class BanCog(commands.Cog):
         if not member:
             return await ctx.respond(f"User {user} not found.")
         await add_evidence_note(member.id, "ban", reason, evidence, ctx.user.id)
-        response = await ban_member(self.bot, ctx.guild, member, duration, reason, ctx.user, needs_approval=True)
+        response = await ban_member(
+            self.bot, ctx.guild, member, duration, reason, evidence, ctx.user, needs_approval=True
+        )
         return await ctx.respond(response.message, delete_after=response.delete_after)
 
     @slash_command(guild_ids=settings.guild_ids, description="Unbans a user from the server.")

--- a/src/helpers/ban.py
+++ b/src/helpers/ban.py
@@ -51,7 +51,7 @@ async def _get_ban_or_create(member: Member, ban: Ban, infraction: Infraction) -
 
 
 async def ban_member(
-    bot: Bot, guild: Guild, member: Member | User, duration: str, reason: str, author: Member = None,
+    bot: Bot, guild: Guild, member: Member | User, duration: str, reason: str, evidence: str, author: Member = None,
     needs_approval: bool = True
 ) -> SimpleResponse | None:
     """Ban a member from the guild."""
@@ -144,7 +144,9 @@ async def ban_member(
         embed = discord.Embed(
             title=f"Ban request #{ban_id}",
             description=f"{author.display_name} ({author.name}) "
-                        f"would like to ban {member_name} until {end_date} (UTC). Reason: {reason}", )
+                        f"would like to ban {member_name} until {end_date} (UTC).\n"
+                        f"Reason: {reason}\n"
+                        f"Evidence: {evidence}", )
         embed.set_thumbnail(url=f"{settings.HTB_URL}/images/logo600.png")
         view = BanDecisionView(ban_id, bot, guild, member, end_date, reason)
         await guild.get_channel(settings.channels.SR_MOD).send(embed=embed, view=view)

--- a/tests/src/cmds/core/test_ban.py
+++ b/tests/src/cmds/core/test_ban.py
@@ -34,7 +34,7 @@ class TestBanCog:
             # Assertions
             add_evidence_note_mock.assert_called_once_with(user.id, "ban", "Any valid reason", "Some evidence", ctx.user.id)
             ban_member_mock.assert_called_once_with(
-                bot, ctx.guild, user, "500w", "Any valid reason", ctx.user, needs_approval=False
+                bot, ctx.guild, user, "500w", "Any valid reason", "Some evidence", ctx.user, needs_approval=False
             )
             ctx.respond.assert_called_once_with(
                 f"Member {user.display_name} has been banned permanently.", delete_after=0
@@ -61,7 +61,7 @@ class TestBanCog:
             # Assertions
             add_evidence_note_mock.assert_called_once_with(user.id, "ban", "Any valid reason", "Some evidence", ctx.user.id)
             ban_member_mock.assert_called_once_with(
-                bot, ctx.guild, user, "5d", "Any valid reason", ctx.user, needs_approval=True
+                bot, ctx.guild, user, "5d", "Any valid reason", "Some evidence", ctx.user, needs_approval=True
             )
             ctx.respond.assert_called_once_with(
                 f"Member {user.display_name} has been banned temporarily.", delete_after=0
@@ -87,11 +87,11 @@ class TestBanCog:
             ban_member_mock.return_value = ban_response
 
             cog = ban.BanCog(bot)
-            await cog.tempban.callback(cog, ctx, user, "5", "Any valid reason")
+            await cog.tempban.callback(cog, ctx, user, "5", "Any valid reason", "Some evidence")
 
             # Assertions
             ban_member_mock.assert_called_once_with(
-                bot, ctx.guild, user, "5", "Any valid reason", ctx.user, needs_approval=True
+                bot, ctx.guild, user, "5", "Any valid reason", "Some evidence", ctx.user, needs_approval=True
             )
             ctx.respond.assert_called_once_with(
                 "Malformed duration. Please use duration units, (e.g. 12h, 14d, 5w).", delete_after=15

--- a/tests/src/helpers/test_ban.py
+++ b/tests/src/helpers/test_ban.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from discord import Forbidden, HTTPException
@@ -113,6 +113,7 @@ class TestBanMember:
     async def test_ban_member_valid_duration(self, bot, guild, member, author):
         duration = "1d"
         reason = "xf reason"
+        evidence = "Some evidence"
         member.display_name = "Banned Member"
 
         with (
@@ -125,7 +126,7 @@ class TestBanMember:
             mock_channel.send.return_value = MagicMock()
             guild.get_channel.return_value = mock_channel
 
-            result = await ban_member(bot, guild, member, duration, reason)
+            result = await ban_member(bot, guild, member, duration, reason, evidence)
             assert isinstance(result, SimpleResponse)
             assert result.message == f"{member.display_name} ({member.id}) has been banned until 2023-05-16 22:41:40 " \
                                      f"(UTC)."
@@ -134,20 +135,22 @@ class TestBanMember:
     async def test_ban_member_invalid_duration(self, bot, guild, member, author):
         duration = "1d"
         reason = "xf reason"
+        evidence = "Some evidence"
         member.display_name = "Banned Member"
 
         with (
             mock.patch("src.helpers.ban._check_member", return_value=None),
             mock.patch("src.helpers.ban.validate_duration", return_value=(0, "Invalid duration: could not parse.")),
         ):
-            result = await ban_member(bot, guild, member, duration, reason)
+            result = await ban_member(bot, guild, member, duration, reason, evidence)
             assert isinstance(result, SimpleResponse)
             assert result.message == "Invalid duration: could not parse."
 
     @pytest.mark.asyncio
     async def test_ban_member_permanently_success(self, bot, guild, member, author):
         duration = "500w"
-        reason = 'Why not?'
+        reason = "Why not?"
+        evidence = "Some evidence"
         member.display_name = "Banned Member"
 
         # Patching the necessary classes and functions
@@ -157,14 +160,15 @@ class TestBanMember:
             mock.patch("src.helpers.ban._get_ban_or_create", return_value=(1, False)),
             mock.patch("src.helpers.ban.validate_duration", return_value=(1684276900, "")),
         ):
-            response = await ban_member(bot, guild, member, duration, reason, author, False)
+            response = await ban_member(bot, guild, member, duration, reason, evidence, author, False)
             assert isinstance(response, SimpleResponse)
             assert response.message == f"Member {member.display_name} has been banned permanently."
 
     @pytest.mark.asyncio
     async def test_ban_member_no_reason_success(self, bot, guild, member, author):
         duration = "500w"
-        reason = ''
+        reason = ""
+        evidence = "Some evidence"
         member.display_name = "Banned Member"
 
         # Patching the necessary classes and functions
@@ -174,14 +178,15 @@ class TestBanMember:
             mock.patch("src.helpers.ban._get_ban_or_create", return_value=(1, False)),
             mock.patch("src.helpers.ban.validate_duration", return_value=(1684276900, "")),
         ):
-            response = await ban_member(bot, guild, member, duration, reason, author, False)
+            response = await ban_member(bot, guild, member, duration, reason, evidence, author, False)
             assert isinstance(response, SimpleResponse)
             assert response.message == f"Member {member.display_name} has been banned permanently."
 
     @pytest.mark.asyncio
     async def test_ban_member_no_author_success(self, bot, guild, member):
         duration = '500w'
-        reason = ''
+        reason = ""
+        evidence = "Some evidence"
         member.display_name = "Banned Member"
 
         with (
@@ -190,14 +195,15 @@ class TestBanMember:
             mock.patch("src.helpers.ban._get_ban_or_create", return_value=(1, False)),
             mock.patch("src.helpers.ban.validate_duration", return_value=(1684276900, "")),
         ):
-            response = await ban_member(bot, guild, member, duration, reason, None, False)
+            response = await ban_member(bot, guild, member, duration, reason, evidence, None, False)
             assert isinstance(response, SimpleResponse)
             assert response.message == f"Member {member.display_name} has been banned permanently."
 
     @pytest.mark.asyncio
     async def test_ban_already_exists(self, bot, guild, member, author):
         duration = '500w'
-        reason = ''
+        reason = ""
+        evidence = "Some evidence"
         member.display_name = "Banned Member"
 
         with (
@@ -206,7 +212,7 @@ class TestBanMember:
             mock.patch("src.helpers.ban._get_ban_or_create", return_value=(1, True)),
             mock.patch("src.helpers.ban.validate_duration", return_value=(1684276900, "")),
         ):
-            response = await ban_member(bot, guild, member, duration, reason, author)
+            response = await ban_member(bot, guild, member, duration, reason, evidence, author)
             assert isinstance(response, SimpleResponse)
             assert response.message == f"A ban with id: 1 already exists for member {member}"
 
@@ -216,7 +222,7 @@ class TestBanMember:
         user = helpers.MockMember(id=2, name="Banned User")
         with patch('src.helpers.ban.member_is_staff', return_value=True):
             response = await ban_member(
-                bot, guild, user, "1d", "spamming", author=ctx.user, needs_approval=True
+                bot, guild, user, "1d", "spamming", "some evidence", author=ctx.user, needs_approval=True
             )
 
         assert isinstance(response, SimpleResponse)
@@ -228,7 +234,7 @@ class TestBanMember:
         member = helpers.MockMember(id=2, name="Bot Member", bot=True)
         with patch('src.helpers.ban.member_is_staff', return_value=False):
             response = await ban_member(
-                bot, guild, member, "1d", "spamming", author=ctx.user, needs_approval=True
+                bot, guild, member, "1d", "spamming", "some evidence", author=ctx.user, needs_approval=True
             )
 
         assert isinstance(response, SimpleResponse)
@@ -239,7 +245,7 @@ class TestBanMember:
         ctx.user = helpers.MockMember(id=1, name="Test User")
         with patch('src.helpers.ban.member_is_staff', return_value=False):
             response = await ban_member(
-                bot, guild, ctx.user, "1d", "spamming", author=ctx.user, needs_approval=True
+                bot, guild, ctx.user, "1d", "spamming", "some evidence", author=ctx.user, needs_approval=True
             )
 
         assert isinstance(response, SimpleResponse)


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
*Put an `x` in the boxes that apply.*

- [ ] Bugfix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes

This feature will add the _evidence_ field in the _ban request overview_. Tests were altered accordingly.  

## Checklist

*Put an `x` in the boxes that apply.*

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [X] Lint and unit tests pass locally with my changes.
- [X] I have added the necessary documentation (if appropriate).

## Additional context

### Evidence provided
_Plain text_
<img width="531" alt="Screenshot 2024-11-22 at 13 31 04" src="https://github.com/user-attachments/assets/09d20ef4-8236-40ce-a4b8-49dfcab098db">

_With discord link_
<img width="545" alt="Screenshot 2024-11-22 at 13 37 12" src="https://github.com/user-attachments/assets/7edb6b4f-050e-46e3-91b4-cbdac28157b2">


### No evidence provided
<img width="575" alt="Screenshot 2024-11-22 at 13 31 48" src="https://github.com/user-attachments/assets/f5efc763-148e-4688-ad10-edc23e70beae">

