### PR TITLE
[FEATURE] Allow ALL_MODS to use `/cleanup`

### DIFF
--- a/src/cmds/core/channel.py
+++ b/src/cmds/core/channel.py
@@ -50,7 +50,11 @@ class ChannelCog(commands.Cog):
         return await ctx.respond(f"Slow-mode set in {channel.name} to {seconds} seconds.")
 
     @slash_command(guild_ids=settings.guild_ids)
-    @has_any_role(*settings.role_groups.get("ALL_ADMINS"), *settings.role_groups.get("ALL_SR_MODS"))
+    @has_any_role(
+        *settings.role_groups.get("ALL_ADMINS"),
+        *settings.role_groups.get("ALL_SR_MODS"),
+        *settings.role_groups.get("ALL_MODS")
+    )
     async def cleanup(
         self, ctx: ApplicationContext,
         count: Option(int, "How many messages to delete", required=True, default=5),


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
This code change will allow moderators to use the `/cleanup` command

- [ ] Bugfix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes

Added the role ALL_MODS to the permissions list. Only merge if approved.

## Checklist

*Put an `x` in the boxes that apply.*

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [X] Lint and unit tests pass locally with my changes.
- [X] I have added the necessary documentation (if appropriate).

## Additional context


