### PR TITLE
[IMPROVEMENT] Changed the error message when adding an infraction

### DIFF
--- a/src/helpers/ban.py
+++ b/src/helpers/ban.py
@@ -280,7 +280,7 @@ async def add_infraction(
             f"Following is the reason given:\n>>> {reason}\n"
         )
     except Forbidden as ex:
-        message = "Could not DM member due to privacy settings, however will still attempt to ban them..."
+        message = "Could not DM member due to privacy settings, however the infraction was still added."
         logger.warning(f"Forbidden, when trying to contact user with ID {member.id} about infraction.", exc_info=ex)
     except HTTPException as ex:
         message = "Here's a 400 Bad Request for you. Just like when you tried to ask me out, last week."


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
*Put an `x` in the boxes that apply.*

- [X] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes

When adding an infraction and Hackster cannot dm the user due to permissions, it will send an error message: 
"Could not DM member due to privacy settings, however will still attempt to ban them..."

The user is not being banned. This can cause confusion. Also added some testing for it. 

## Checklist

*Put an `x` in the boxes that apply.*

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [X] Lint and unit tests pass locally with my changes.
- [X] I have added the necessary documentation (if appropriate).

## Additional context

Add any other context or screenshots here.
