### PR TITLE
[IMPROVEMENT] Show an error message in case the user already left when kicking

### DIFF
--- a/src/cmds/core/user.py
+++ b/src/cmds/core/user.py
@@ -67,6 +67,8 @@ class UserCog(commands.Cog):
             -> Interaction | WebhookMessage:
         """Kick a user from the server."""
         member = await self.bot.get_member_or_user(ctx.guild, user.id)
+        if not isinstance(member, discord.Member):
+            return await ctx.respond("User seems to have already left the server.")
         if not member:
             return await ctx.respond(f"User {user} not found.")
         if member_is_staff(member):

--- a/tests/src/cmds/core/test_user.py
+++ b/tests/src/cmds/core/test_user.py
@@ -40,6 +40,25 @@ class TestUserCog:
             ctx.guild.kick.assert_called_once_with(user=user_to_kick, reason="Violation of rules")
             ctx.respond.assert_called_once_with("User to Kick got the boot!")
 
+    @pytest.mark.asyncio
+    async def test_kick_fail_user_left(self, ctx, guild, bot, session):
+        ctx.user = helpers.MockMember(id=1, name="Test Moderator")
+        user_to_kick = helpers.MockMember(id=2, name="User to Kick", bot=False)
+        ctx.guild = guild
+        ctx.guild.kick = AsyncMock()
+        bot.get_member_or_user = AsyncMock(return_value=None)
+
+        # Ensure the member_is_staff mock doesn't block execution
+        with patch('src.cmds.core.user.member_is_staff', return_value=False):
+            cog = user.UserCog(bot)
+            await cog.kick.callback(cog, ctx, user_to_kick, "Violation of rules")
+
+            # Assertions
+            bot.get_member_or_user.assert_called_once_with(ctx.guild, user_to_kick.id)
+            ctx.guild.kick.assert_not_called()  # No kick should occur
+            ctx.respond.assert_called_once_with("User seems to have already left the server.")
+
+
     def test_setup(self, bot):
         """Test the setup method of the cog."""
         # Invoke the command


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
*Put an `x` in the boxes that apply.*

- [X] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes

If you try to kick a user that already left the server, the bot won't respond. This PR adds an error message and a test function for this.

Thanks Rem for the idea.

## Checklist

*Put an `x` in the boxes that apply.*

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [X] Lint and unit tests pass locally with my changes.
- [X] I have added the necessary documentation (if appropriate).

## Additional context

Add any other context or screenshots here.
