### PR TITLE
[IMPROVEMENT] - add warning before submitting spoiler

### DIFF
--- a/src/cmds/core/other.py
+++ b/src/cmds/core/other.py
@@ -61,7 +61,7 @@ class SpoilerModal(Modal):
         """Initialize the Spoiler Modal with input fields."""
         super().__init__(*args, **kwargs)
         self.add_item(InputText(label="Description", placeholder="Description", required=False, style=discord.InputTextStyle.long))
-        self.add_item(InputText(label="URL", placeholder="Enter URL", required=True, style=discord.InputTextStyle.long))
+        self.add_item(InputText(label="URL", placeholder="Enter URL. Submitting malicious or fake links will result in consequences.", required=True, style=discord.InputTextStyle.paragraph))
 
     async def callback(self, interaction: discord.Interaction) -> None:
         """Handle the modal submission by sending the spoiler report to JIRA."""

--- a/src/cmds/core/other.py
+++ b/src/cmds/core/other.py
@@ -3,7 +3,7 @@ import logging
 import discord
 from discord import ApplicationContext, Interaction, Message, Option, slash_command
 from discord.ext import commands
-from discord.ui import InputText, Modal
+from discord.ui import Button, InputText, Modal, View
 from slack_sdk.webhook import WebhookClient
 
 from src.bot import Bot
@@ -60,8 +60,22 @@ class SpoilerModal(Modal):
     def __init__(self, *args, **kwargs) -> None:
         """Initialize the Spoiler Modal with input fields."""
         super().__init__(*args, **kwargs)
-        self.add_item(InputText(label="Description", placeholder="Description", required=False, style=discord.InputTextStyle.long))
-        self.add_item(InputText(label="URL", placeholder="Enter URL. Submitting malicious or fake links will result in consequences.", required=True, style=discord.InputTextStyle.paragraph))
+        self.add_item(
+            InputText(
+                label="Description",
+                placeholder="Description",
+                required=False,
+                style=discord.InputTextStyle.long
+            )
+        )
+        self.add_item(
+            InputText(
+                label="URL",
+                placeholder="Enter URL. Submitting malicious or fake links will result in consequences.",
+                required=True,
+                style=discord.InputTextStyle.paragraph
+            )
+        )
 
     async def callback(self, interaction: discord.Interaction) -> None:
         """Handle the modal submission by sending the spoiler report to JIRA."""
@@ -84,6 +98,25 @@ class SpoilerModal(Modal):
         }
 
         await webhook.webhook_call(webhook_url, data)
+
+
+class SpoilerConfirmationView(View):
+    """A confirmation view before opening the SpoilerModal."""
+
+    def __init__(self, user: discord.Member):
+        super().__init__(timeout=60)
+        self.user = user
+
+    @discord.ui.button(label="Proceed", style=discord.ButtonStyle.danger)
+    async def proceed(self, button: Button, interaction: discord.Interaction) -> None:
+        """Opens the spoiler modal after confirmation."""
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message("This confirmation is not for you.", ephemeral=True)
+            return
+
+        modal = SpoilerModal(title="Report Spoiler")
+        await interaction.response.send_modal(modal)
+        self.stop()
 
 
 class OtherCog(commands.Cog):
@@ -116,10 +149,14 @@ class OtherCog(commands.Cog):
         )
 
     @slash_command(guild_ids=settings.guild_ids, description="Add a URL which contains a spoiler.")
-    async def spoiler(self, ctx: ApplicationContext) -> Interaction:
-        """Report a URL that contains a spoiler."""
-        modal = SpoilerModal(title="Report Spoiler")
-        return await ctx.send_modal(modal)
+    async def spoiler(self, ctx: ApplicationContext) -> None:
+        """Ask for confirmation before reporting a spoiler."""
+        view = SpoilerConfirmationView(ctx.user)
+        await ctx.respond(
+            "Thank you for taking the time to report a spoiler. \n ⚠️ **Warning:** Submitting malicious or fake links will result in consequences.",
+            view=view,
+            ephemeral=True
+        )
 
     @slash_command(guild_ids=settings.guild_ids, description="Provide feedback to HTB.")
     @commands.cooldown(1, 60, commands.BucketType.user)


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
*Put an `x` in the boxes that apply.*

- [ ] Bugfix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes

A feature request was made to add a warning message before being able to submit a spoiler. Recently people have been submitting malicious/fake links. Also changed the placeholder for the URL field so that the user is warned twice.

## Checklist

*Put an `x` in the boxes that apply.*

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [X] Lint and unit tests pass locally with my changes.
- [X] I have added the necessary documentation (if appropriate).

## Additional context

After the `/spoiler` command is triggered, an ephermal message will show. Clicking the Proceed button will open the spoiler modal. 

<img width="620" alt="Screenshot 2025-02-11 at 12 00 20" src="https://github.com/user-attachments/assets/6570f799-b493-4393-adcd-4f487cb86fc5" />

<img width="516" alt="Screenshot 2025-02-11 at 12 01 02" src="https://github.com/user-attachments/assets/2e8cd66c-2c2b-4433-b334-3278e2549e78" />
