### PR TITLE
Add CWES as synonym for CBBH for new cert holders

### DIFF
--- a/src/helpers/verification.py
+++ b/src/helpers/verification.py
@@ -94,6 +94,8 @@ async def process_certification(certid: str, name: str):
         return False
     if certRawName == "HTB Certified Bug Bounty Hunter":
         cert = "CBBH"
+    elif certRawName == "HTB Certified Web Exploitation Specialist":
+        cert = "CBBH"
     elif certRawName == "HTB Certified Penetration Testing Specialist":
         cert = "CPTS"
     elif certRawName == "HTB Certified Defensive Security Analyst":


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
*Put an `x` in the boxes that apply.*

- [X] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes

CWES is now also assigned to CBBH role

## Checklist

*Put an `x` in the boxes that apply.*

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [X] Lint and unit tests pass locally with my changes.
- [X] I have added the necessary documentation (if appropriate).

## Additional context

Right now the API sends the CWES name for newer certs causing new cert holders not being able to verify
