### PR TITLE
Switch season rank API to user achievement endpoint

### DIFF
--- a/src/helpers/verification.py
+++ b/src/helpers/verification.py
@@ -132,7 +132,7 @@ async def get_user_details(labs_id: int | str) -> dict:
 
 async def get_season_rank(htb_uid: int) -> str | None:
     """Get season rank from HTB."""
-    season_api_url = f"{settings.API_V4_URL}/season/end/{settings.SEASON_ID}/{htb_uid}"
+    season_api_url = f"{settings.API_V4_URL}/user/achievement/season/{htb_uid}/{settings.SEASON_ID}"
 
     async with get_labs_session() as session:
         async with session.get(season_api_url) as r:

--- a/tests/src/helpers/test_verification.py
+++ b/tests/src/helpers/test_verification.py
@@ -6,8 +6,38 @@ import discord
 import pytest
 
 from src.core import settings
-from src.helpers.verification import get_user_details, process_labs_identification
+from src.helpers.verification import get_season_rank, get_user_details, process_labs_identification
 from tests.helpers import MockRoleManager
+
+
+class TestGetSeasonRank(unittest.IsolatedAsyncioTestCase):
+    @pytest.mark.asyncio
+    async def test_get_season_rank_success(self):
+        htb_uid = 12345
+
+        with aioresponses.aioresponses() as m:
+            m.get(
+                f"{settings.API_V4_URL}/user/achievement/season/{htb_uid}/{settings.SEASON_ID}",
+                status=200,
+                payload={"data": {"season": {"tier": "Gold"}}},
+            )
+
+            result = await get_season_rank(htb_uid)
+            self.assertEqual(result, "Gold")
+
+    @pytest.mark.asyncio
+    async def test_get_season_rank_empty_data(self):
+        htb_uid = 12345
+
+        with aioresponses.aioresponses() as m:
+            m.get(
+                f"{settings.API_V4_URL}/user/achievement/season/{htb_uid}/{settings.SEASON_ID}",
+                status=200,
+                payload={"data": None},
+            )
+
+            result = await get_season_rank(htb_uid)
+            self.assertIsNone(result)
 
 
 class TestGetUserDetails(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
*Put an `x` in the boxes that apply.*

- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected).
- [ ] Documentation Update (if none of the other choices applies).

## Proposed changes

Update `get_season_rank` to call `v4/user/achievement/season/{userId}/{modelId}` instead of the old `v4/season/end/{seasonId}/{userId}` endpoint.

Per @shad0wn0mad (platform), we were asked to switch to this endpoint; they confirmed the response schema is the same, so existing rank/tier parsing is unchanged.

Also adds unit coverage for the new URL and empty-data handling.

## Checklist

*Put an `x` in the boxes that apply.*

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/hackthebox/Hackster/blob/main/CONTRIBUTING.md)
  doc.
- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added the necessary documentation (if appropriate).

## Additional context

- Old: `{API_V4_URL}/season/end/{SEASON_ID}/{htb_uid}`
- New: `{API_V4_URL}/user/achievement/season/{htb_uid}/{SEASON_ID}`

Made with [Cursor](https://cursor.com)